### PR TITLE
Tests for fetch_oui_from_custom

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -12,6 +12,7 @@ README.pod
 t/compile.t
 t/extract_oui_from_html.t
 t/fetch_oui.t
+t/fetch_oui_from_custom.t
 t/fetch_oui_from_ieee.t
 t/load_cache.t
 t/normalize_mac.t

--- a/lib/Net/MAC/Vendor.pm
+++ b/lib/Net/MAC/Vendor.pm
@@ -235,7 +235,7 @@ sub fetch_oui_from_custom {
 
 	return unless defined $url;
 
-	my $html = __PACKAGE__->ua->get( $url );
+	my $html = __PACKAGE__->_fetch_oui_from_url( $url );
 	unless( defined $html ) {
 		carp "Could not fetch data from the IEEE!";
 		return;

--- a/t/fetch_oui_from_custom.t
+++ b/t/fetch_oui_from_custom.t
@@ -1,0 +1,31 @@
+use Test::More 0.98;
+
+use Data::Dumper;
+my $class = 'Net::MAC::Vendor';
+
+diag( "Some tests have to fetch data files and can take a long time" );
+
+subtest setup => sub {
+	use_ok( $class );
+	ok( defined &{"${class}::fetch_oui_from_custom"}, "&fetch_oui_from_custom is defined" );
+	};
+
+subtest fetch => sub {
+	my $i = 0;
+	for my $url (undef, 'http://standards.ieee.org/cgi-bin/ouisearch?14-10-9F', undef) {
+		if ($i > 1) { $ENV{NET_MAC_VENDOR_OUI_SOURCE} = 
+			'http://standards.ieee.org/cgi-bin/ouisearch?14-10-9F' };
+		my $array = Net::MAC::Vendor::fetch_oui_from_custom( '14:10:9F', $url );
+
+		SKIP: {
+			skip "Couldn't fetch data, which happens, so no big whoop", 2
+				unless defined $array;
+			isa_ok( $array, ref [], "Got back array reference" );
+			my $html = join "\n", @$array;
+			like( $html, qr/Apple, Inc\./, "Fetched Apple's OUI entry" );
+			}
+		$i++;
+		}
+	};
+
+done_testing();

--- a/t/test_manifest
+++ b/t/test_manifest
@@ -4,6 +4,7 @@ pod_coverage.t
 normalize_mac.t
 oui.t
 fetch_oui_from_ieee.t
+fetch_oui_from_custom.t
 extract_oui_from_html.t
 parse_oui.t
 fetch_oui.t


### PR DESCRIPTION
As discussed in issue #19 here are some tests for fetch_oui_from_custom. I've based them on the existing tests of other methods so you should hopefully find the structure familiar.

Also, I've made one small change to the method itself such that it now calls _fetch_oui_from_url() internally rather than just the plain ua->get. This means that it benefits from all the same error handling as the other data-retrieval methods.

I hope you find these useful. Sorry for the delay in getting them to you.