### PR TITLE
do not require Compress::* libraries for parsing data file, to allow for fatpacking

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl module Net::MAC::Vendor
 
+	* Compress::Bzip2 and Compress::Zlib are now optional prerequisites if
+	PUREPERL_ONLY=1 is specified as a Makefile.PL argument (or e.g. via `cpanm --pureperl`,
+	or PERL_MM_OPT=PUREPERL_ONLY=1 in the environment).
+
 1.262 2017-08-10T06:45:18Z
 	* Fix docs for load_cache (GitHub #23, Matt W.). Mojo::UserAgent
 	doesn't handle file://

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -68,11 +68,10 @@ my %WriteMakefile = (
 		'File::Temp'       => '0',
 		'Mojo::URL'        => '0',
 		'Mojo::UserAgent'  => '0',
-		'Compress::Bzip2'  => '0',
-		'Compress::Zlib'   => '0',
 		},
 
 	'META_MERGE' => {
+		dynamic_config => 1,
 		'meta-spec' => { version => 2 },
 		resources => {
 			repository => {
@@ -84,6 +83,14 @@ my %WriteMakefile = (
 				web    => "$github/issues",
 				},
 			homepage => $github,
+			},
+		prereqs => {
+			runtime => {
+				recommends => {
+					'Compress::Bzip2'  => '0',
+					'Compress::Zlib'   => '0',
+					},
+				},
 			},
 		},
 
@@ -104,12 +111,29 @@ sub do_it {
 	eval "use Test::Manifest 1.21"
 		if -e File::Spec->catfile( qw(t test_manifest) );
 
+	if (not parse_args()->{PUREPERL_ONLY}) {
+		$WriteMakefile{PREREQ_PM}{'Compress::Bzip2'} = 0;
+		$WriteMakefile{PREREQ_PM}{'Compress::Zlib'} = 0;
+	}
+
 	my $arguments = arguments();
 	my $minimum_perl = $arguments->{MIN_PERL_VERSION} || '5.008';
 	eval "require $minimum_perl;" or die $@;
 
 	WriteMakefile( %$arguments );
 	}
+
+sub parse_args {
+  # copied from EUMM
+  require ExtUtils::MakeMaker;
+  require Text::ParseWords;
+  ExtUtils::MakeMaker::parse_args(
+    my $tmp = {},
+    Text::ParseWords::shellwords($ENV{PERL_MM_OPT} || ''),
+    @ARGV,
+  );
+  return $tmp->{ARGS} || {};
+}
 
 no warnings;
 __PACKAGE__;

--- a/lib/Net/MAC/Vendor.pm
+++ b/lib/Net/MAC/Vendor.pm
@@ -41,7 +41,7 @@ as a script with a list of MAC addresses as arguments. The module can
 figure it out.
 
 The IEEE moves the location of its OUI file. If they do that again, you
-can set the C<NET_MAC_VENDER_OUI_URL> environment variable to get the new
+can set the C<NET_MAC_VENDOR_OUI_URL> environment variable to get the new
 URL without updating the code.
 
 Here are some of the old URLs, which also flip-flop schemes:


### PR DESCRIPTION
thank you very much for this module. We plan to use it in an environment where system resources, such as a compiler, may be limited, and therefore will be fatpacking all requirements for our application.  This patch makes the Compress::* modules optional when `PUREPERL_ONLY=1` is specified as a makefile environment (`cpanm --pp` will set this automatically, or it can be set in the environment as PERL_MM_OPT=PUREPERL_ONLY=1 when running cpanplus etc.)

I tried to follow your formatting convention and the way you've structured Makefile.PL. I'd be happy to make any adjustments you like.

I didn't find a test that explicitly tested `NET_MAC_VENDOR_OUI_URL`, so I tested by hand with:

```
use strict;
use warnings;
use Net::MAC::Vendor;

$ENV{NET_MAC_VENDOR_OUI_URL} = 'http://linuxnet.ca/ieee/oui.txt.bz2';

use Data::Dumper;
Net::MAC::Vendor::load_cache();
print STDERR Dumper(Net::MAC::Vendor::fetch_oui('00-0D-93'));
print STDERR Dumper(Net::MAC::Vendor::fetch_oui_from_custom('00-0D-93'));
```